### PR TITLE
Feature/copy yarn lock

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 COPY_YARN_LOCK="$(cat "${ENV_DIR}/COPY_YARN_LOCK")"
 (
     if [ "${COPY_YARN_LOCK}" = "true" ]; then
-        cp "${BUILD_DIR}/yarn.lock" "${STAGE}/${APP_BASE}"
+        cp "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}"
     fi
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
     rm -rf "${BUILD_DIR}"/* &&

--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ COPY_YARN_LOCK="$(cat "${ENV_DIR}/COPY_YARN_LOCK")"
         cp "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}"
     fi
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    rm -rf "${BUILD_DIR}"/* &&
+    rm -rf "${BUILD_DIR:?}"/* &&
     mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}"
 )
 

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,11 @@ if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
 fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
+COPY_YARN_LOCK="$(cat "${ENV_DIR}/COPY_YARN_LOCK")"
 (
+    if [ "${COPY_YARN_LOCK}" = "true" ]; then
+        cp "${BUILD_DIR}/yarn.lock" "${STAGE}/${APP_BASE}"
+    fi
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
     rm -rf "${BUILD_DIR}"/* &&
     mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}"


### PR DESCRIPTION
## Context

Our analytics-api CI environment is currently running different versions of packages compared with our local dev environments. We want to try and use our yarn.lock file to control what is loaded in CI.

## Changes
- Copy yarn.lock into the analytics-api package during the buildpack build process
- Fix a bug which could run rm -rf /* if a variable is missing.